### PR TITLE
add more support for books on the lectern

### DIFF
--- a/src/main/java/am2/blocks/tileentities/TileEntityLectern.java
+++ b/src/main/java/am2/blocks/tileentities/TileEntityLectern.java
@@ -210,7 +210,7 @@ public class TileEntityLectern extends TileEntityEnchantmentTable{
 	}
 
 	public boolean setStack(ItemStack stack){
-		if (stack == null || getValidItems().contains(stack.getItem())){
+		if (stack == null || isValidBook(stack)){
 			this.stack = stack;
 			if (!this.worldObj.isRemote){
 				AMDataWriter writer = new AMDataWriter();
@@ -247,20 +247,31 @@ public class TileEntityLectern extends TileEntityEnchantmentTable{
 		this.readFromNBT(pkt.func_148857_g());
 	}
 
-	private ArrayList<Item> getValidItems(){
-		ArrayList<Item> validItems = new ArrayList<Item>();
+	private boolean isValidBook(ItemStack stack){
+		String name = stack.getUnlocalizedName();
+		String[] validBooks = AMCore.config.getAllowedBooks();
 
-		validItems.add(Items.written_book);
-		validItems.add(ItemsCommonProxy.arcaneCompendium);
+    // blacklist items/mods that don't work
+		// witchery: the code expects the book to be in the hand of the player
+		String[] blackList = new String[]{"witchery"};
 
-		if (Loader.isModLoaded("Thaumcraft")){
-			ItemStack item = thaumcraft.api.ItemApi.getItem("itemThaumonomicon", 0);
-			if (item != null){
-				validItems.add(item.getItem());
+
+		boolean valid = false;
+		for(String bookpart: validBooks) {
+			if(name.matches( "(?i).*" + bookpart + ".*")) {
+				valid = true;
+				continue;
 			}
 		}
 
-		return validItems;
+		for(String bookpart: blackList) {
+			if(name.matches( ".*" + bookpart + ".*")) {
+				valid = false;
+				continue;
+			}
+		}
+
+		return valid;
 	}
 
 	@Override

--- a/src/main/java/am2/configuration/AMConfig.java
+++ b/src/main/java/am2/configuration/AMConfig.java
@@ -77,34 +77,34 @@ public class AMConfig extends Configuration{
 	private final String KEY_EnableWitchwoodForest = "Enable_Witchwood_Forests";
 
 	private final String KEY_allowCreativeTargets = "Allow_Creative_Targets";
-	
+
 	private final String KEY_WitchwoodFrequency = "WitchwoodFrequency";
 	private final String KEY_EssenceLakeFrequency = "EssenceLakeFrequency";
 	private final String KEY_WakebloomFrequency = "WakebloomFrequency";
 	private final String KEY_FlowerGenAttempts = "FlowerGenAttempts";
-	
+
 	private final String KEY_VinteumMin = "VinteumMinHeight";
 	private final String KEY_VinteumMax = "VinteumMaxHeight";
 	private final String KEY_VinteumVein = "VinteumVeinSize";
 	private final String KEY_VinteumFreq = "VinteumFrequency";
-	
+
 	private final String KEY_ChimeriteMin = "ChimeriteMinHeight";
 	private final String KEY_ChimeriteMax = "ChimeriteMaxHeight";
 	private final String KEY_ChimeriteVein = "ChimeriteVeinSize";
 	private final String KEY_ChimeriteFreq = "ChimeriteFrequency";
-	
+
 	private final String KEY_TopazMin = "TopazMinHeight";
 	private final String KEY_TopazMax = "TopazMaxHeight";
 	private final String KEY_TopazVein = "TopazVeinSize";
 	private final String KEY_TopazFreq = "TopazFrequency";
-	
+
 	private final String KEY_SunstoneMin = "SunstoneMinHeight";
 	private final String KEY_SunstoneMax = "SunstoneMaxHeight";
 	private final String KEY_SunstoneVein = "SunstoneVeinSize";
 	private final String KEY_SunstoneFreq = "SunstoneFrequency";
-	
-	private final String KEY_AllowDamageModifier = "AllowDamageModifier";	
-	
+
+	private final String KEY_AllowDamageModifier = "AllowDamageModifier";
+
 	/**
 	 * Beta Particles
 	 **/
@@ -169,6 +169,8 @@ public class AMConfig extends Configuration{
 	private final String KEY_ShowXPAlways = "ShowXPAlways";
 	private final String KEY_ShowHUDBars = "ShowHUDBars";
 	private final String KEY_ColourblindMode = "ColourblindMode";
+
+	private final String KEY_allowedBooks = "AllowedBooks";
 	/**
 	 * End GUI Config
 	 **/
@@ -203,7 +205,7 @@ public class AMConfig extends Configuration{
 	private int[] worldgenBlacklist;
 	private boolean enableWitchwoodForest;
 	private int witchwoodForestRarity;
-	
+
 	private boolean allowCreativeTargets;
 
 	private String[] appropriationBlockBlacklist;
@@ -257,33 +259,35 @@ public class AMConfig extends Configuration{
 	private boolean allowCompendiumUpdates;
 	private boolean allowVersionChecks;
 	private boolean canDryadsDespawn;
-	
+
 	private int witchwoodFrequency;
 	private int poolFrequency;
 	private int wakebloomFrequency;
 	private int flowerGenAttempts;
-	
+
 	private int vinteumMinHeight;
 	private int vinteumMaxHeight;
 	private int vinteumVeinSize;
 	private int vinteumFrequency;
-	
+
 	private int chimeriteMinHeight;
 	private int chimeriteMaxHeight;
 	private int chimeriteVeinSize;
 	private int chimeriteFrequency;
-	
+
 	private int topazMinHeight;
 	private int topazMaxHeight;
 	private int topazVeinSize;
 	private int topazFrequency;
-	
+
 	private int sunstoneMinHeight;
 	private int sunstoneMaxHeight;
 	private int sunstoneVeinSize;
 	private int sunstoneFrequency;
-	
+
 	private boolean allowDamageModifier;
+
+	private String[] allowedBooks;
 
 	public static final String DEFAULT_LANGUAGE = "en_US";
 
@@ -381,34 +385,34 @@ public class AMConfig extends Configuration{
 		savePowerOnWorldSave = get(CATEGORY_GENERAL, KEY_SavePowerOnWorldSave, true, "Set this to false if you are experiencing tick lage due to AM2 saving power data alongside the world save.  This will instead cache the power data in memory to be saved later.  This comes with more risk in the event of a crash, and a larger memory footprint, but increased performance. Can be used alongside chunk unload save config. Power data is still always saved at world unload (server shutdown).").getBoolean(true);
 
 		canDryadsDespawn = get(CATEGORY_MOBS, KEY_CanDryadsDespawn, true, "Set this to false if you don't want dryads to despawn.").getBoolean(true);
-		
+
 		witchwoodFrequency = get(CATEGORY_GENERAL, KEY_WitchwoodFrequency, 35, "The chance of a witchwood tree generating. Lower numbers give more trees.").getInt(35);
 		poolFrequency = get(CATEGORY_GENERAL, KEY_EssenceLakeFrequency, 25, "The chance of an etherium pool generating. Lower numbers give more pools.").getInt(25);
 		wakebloomFrequency = get(CATEGORY_GENERAL, KEY_WakebloomFrequency, 10, "The chance of a wakebloom generating. Lower numbers give more wakeblooms, and anything less than 7 will attempt to generate in every ocean chunk.").getInt(10);
 		flowerGenAttempts = get(CATEGORY_GENERAL, KEY_FlowerGenAttempts, 8, "The number of flower generation attempts made per chunk. Higher numbers give more flowers, but can slow worldgen.").getInt(8);
-		
+
 		vinteumMinHeight = get(CATEGORY_GENERAL, KEY_VinteumMin, 10, "The minimum height for vinteum to generate.").getInt(10);
 		vinteumMaxHeight = get(CATEGORY_GENERAL, KEY_VinteumMax, 45, "The maximum height for vinteum to generate.").getInt(45);
 		vinteumVeinSize = get(CATEGORY_GENERAL, KEY_VinteumVein, 4, "The number of blocks in a vein of vinteum.").getInt(4);
 		vinteumFrequency = get(CATEGORY_GENERAL, KEY_VinteumFreq, 6, "The number of vinteum veins generated per chunk.").getInt(6);
-		
+
 		chimeriteMinHeight = get(CATEGORY_GENERAL, KEY_ChimeriteMin, 10, "The minimum height for chimerite to generate.").getInt(10);
 		chimeriteMaxHeight = get(CATEGORY_GENERAL, KEY_ChimeriteMax, 80, "The maximum height for chimerite to generate.").getInt(80);
 		chimeriteVeinSize = get(CATEGORY_GENERAL, KEY_ChimeriteVein, 6, "The number of blocks in a vein of chimerite.").getInt(6);
 		chimeriteFrequency = get(CATEGORY_GENERAL, KEY_ChimeriteFreq, 8, "The number of chimerite veins generated per chunk.").getInt(6);
-		
+
 		topazMinHeight = get(CATEGORY_GENERAL, KEY_TopazMin, 10, "The minimum height for topaz to generate.").getInt(10);
 		topazMaxHeight = get(CATEGORY_GENERAL, KEY_TopazMax, 80, "The maximum height for topaz to generate.").getInt(80);
 		topazVeinSize = get(CATEGORY_GENERAL, KEY_TopazVein, 6, "The number of blocks in a vein of topaz.").getInt(6);
 		topazFrequency = get(CATEGORY_GENERAL, KEY_TopazFreq, 8, "The number of topaz veins generated per chunk.").getInt(8);
-		
+
 		sunstoneMinHeight = get(CATEGORY_GENERAL, KEY_SunstoneMin, 5, "The minimum height for sunstone to generate.").getInt(5);
 		sunstoneMaxHeight = get(CATEGORY_GENERAL, KEY_SunstoneMax, 120, "The maximum height for sunstone to generate.").getInt(120);
 		sunstoneVeinSize = get(CATEGORY_GENERAL, KEY_SunstoneVein, 3, "The number of blocks in a vein of sunstone.").getInt(3);
 		sunstoneFrequency = get(CATEGORY_GENERAL, KEY_SunstoneFreq, 20, "The number of sunstone veins generated per chunk.").getInt(20);
-		
+
 		allowDamageModifier = get(CATEGORY_GENERAL, KEY_AllowDamageModifier, true, "This will allow players to cast damage modifer (like Damage, Lunar, Solar) on other players").getBoolean(true);
-		
+
 		enderAffinityAbilityCooldown = get(CATEGORY_GENERAL, KEY_EnderAffinityAbilityCooldown, 100, "Set this to the number of ticks between ender affinity teleports.").getInt();
 
 		String digBlacklistString = get(CATEGORY_GENERAL, KEY_DigDisabledBlocks, "", "Comma-separated list of block IDs that dig cannot break.  If a block is flagged as unbreackable in code, Dig will already be unable to break it.  There is no need to set it here (eg, bedrock, etc.).  Dig also makes use of Forge block harvest checks.  This is mainly for fine-tuning.").getString();
@@ -450,6 +454,21 @@ public class AMConfig extends Configuration{
 				count++;
 			}
 		}
+
+		allowedBooks = get(CATEGORY_GENERAL, KEY_allowedBooks, new String[]{
+			"ArcaneCompendium",
+			"BigBook",
+			"quest_book",
+			"written",
+			"journal",
+			"thaumonomicon",
+			"necronomicon",
+			"lexicon",
+			"print",
+			"library",
+			"tome",
+			"encyclopedia"
+			}, "These are the keywords that are compared against the item names to determine if the item can be placed on a Lectern. Add more keywords if needed.").getStringList();
 
 		initDirectProperties();
 
@@ -735,87 +754,87 @@ public class AMConfig extends Configuration{
 	public boolean getAllowCreativeTargets(){
 		return this.allowCreativeTargets;
 	}
-	
+
 	public int getWitchwoodFrequency(){
 		return this.witchwoodFrequency;
 	}
-	
+
 	public int getPoolFrequency(){
 		return this.poolFrequency;
 	}
-	
+
 	public int getWakebloomFrequency(){
 		return this.wakebloomFrequency;
 	}
-	
+
 	public int getFlowerGenAttempts(){
 		return this.flowerGenAttempts;
 	}
-	
+
 	public int getVinteumMinHeight(){
 		return this.vinteumMinHeight;
 	}
-	
+
 	public int getVinteumMaxHeight(){
 		return this.vinteumMaxHeight;
 	}
-	
+
 	public int getVinteumVeinSize(){
 		return this.vinteumVeinSize;
 	}
-	
+
 	public int getVinteumFrequency(){
 		return this.vinteumFrequency;
 	}
-	
+
 	public int getChimeriteMinHeight(){
 		return this.chimeriteMinHeight;
 	}
-	
+
 	public int getChimeriteMaxHeight(){
 		return this.chimeriteMaxHeight;
 	}
-	
+
 	public int getChimeriteVeinSize(){
 		return this.chimeriteVeinSize;
 	}
-	
+
 	public int getChimeriteFrequency(){
 		return this.chimeriteFrequency;
 	}
-	
+
 	public int getTopazMinHeight(){
 		return this.vinteumMinHeight;
 	}
-	
+
 	public int getTopazMaxHeight(){
 		return this.vinteumMaxHeight;
 	}
-	
+
 	public int getTopazVeinSize(){
 		return this.vinteumVeinSize;
 	}
-	
+
 	public int getTopazFrequency(){
 		return this.vinteumFrequency;
 	}
-	
+
 	public int getSunstoneMinHeight(){
 		return this.sunstoneMinHeight;
 	}
-	
+
 	public int getSunstoneMaxHeight(){
 		return this.sunstoneMaxHeight;
 	}
-	
+
 	public int getSunstoneVeinSize(){
 		return this.sunstoneVeinSize;
 	}
-	
+
 	public int getSunstoneFrequency(){
 		return this.sunstoneFrequency;
 	}
-	
+
 	public boolean getAllowDamageModifer() {
 		return this.allowDamageModifier;
 	}
@@ -959,7 +978,7 @@ public class AMConfig extends Configuration{
 	public int getConfigurablePotionID(String id, int default_value){
 		// because we auto-configure, default_value is ignored
 		int val = getNextFreePotionID();
-		
+
 		if(val == -1 && !hasKey(CATEGORY_POTIONS, id)){
 			LogHelper.error("Cannot find a free potion ID for the %s effect. This will cause severe problems!", id);
 			LogHelper.error("Effect %s has been assigned to a default of potion ID 1 (movement speed). Erroneous behaviour *will* result.", id);
@@ -969,6 +988,10 @@ public class AMConfig extends Configuration{
 		val = prop.getInt(val);
 		save();
 		return val;
+	}
+
+	public String[] getAllowedBooks() {
+		return this.allowedBooks;
 	}
 
 	//====================================================================================

--- a/src/main/java/am2/spell/components/Sounds.java
+++ b/src/main/java/am2/spell/components/Sounds.java
@@ -23,10 +23,10 @@ public class Sounds implements ISpellComponent {
 	public boolean applyEffectEntity(ItemStack stack, World world, EntityLivingBase caster, Entity target) {
 		return applyEffect(stack, world, target.posX, target.posY, target.posZ);
 	}
-	
+
 	public boolean applyEffect(ItemStack stack, World world, double x, double y, double z) {
 		String sound = SpellUtils.instance.getSpellMetadata(stack, "Sound");
-		if (sound.isBlank()) sound = "botania:doit";
+		if (sound.trim().isEmpty()) sound = "botania:doit";
 		world.playSoundEffect(x, y, z, sound, 0.9F, world.rand.nextFloat() - world.rand.nextFloat() * 0.2F + 1.0F);
 		return true;
 	}
@@ -75,7 +75,7 @@ public class Sounds implements ISpellComponent {
 	public float getAffinityShift(Affinity affinity){
 		return 0.0f;
 	}
-	
+
 	public void setSound(ItemStack stack, ItemStack noteblockStack){
 		SpellUtils.instance.setSpellMetadata(stack, "Sound", noteblockStack.getDisplayName());
 	}


### PR DESCRIPTION
Allow Lectern to hold more books. Tested with:

- Vanilla written books (would break spell creation if that no longer worked...)
- Arcane Compendium
- Thaumonomicon (Thaumcraft)
- Lexica Botanica (Botania)
- Encyclopedia Aura (Aura Cascade)
- Big Book (Bibliocraft)

Books that don't work, and so aren't on the whitelist:

- All the Witchery books (crash on right click, the Witchery code expects the book to be in the hand of the player)

Btw. thanks for updating the build process, I could get to a working build without much trouble thanks to your work.
