### PR TITLE
Dimension blacklist for Intervention and Rift

### DIFF
--- a/src/main/java/am2/configuration/SkillConfiguration.java
+++ b/src/main/java/am2/configuration/SkillConfiguration.java
@@ -9,11 +9,20 @@ import java.util.HashMap;
 public class SkillConfiguration extends Configuration{
 	private final HashMap<String, Boolean> cache;
 
+	private static final String CATEGORY_DIMENSION = "dimensions";
+
+	private static final String KEY_intervention_dim_bl = "intervention_dim_bl";
+	private static final String KEY_rift_dim_bl = "rift_dim_bl";
+
+	private int[] intervention_dim_bl;
+	private int[] rift_dim_bl;
+
 	public SkillConfiguration(File file){
 		super(file);
 		cache = new HashMap<String, Boolean>();
 		load();
 		addCustomCategoryComment(CATEGORY_GENERAL, "Set any of these to false to disable the skill in-game.");
+		addCustomCategoryComment(CATEGORY_DIMENSION, "dimension-specific spell settings");
 	}
 
 	public boolean isSkillEnabled(String identifier){
@@ -25,6 +34,15 @@ public class SkillConfiguration extends Configuration{
 	}
 
 	public void init(){
+		intervention_dim_bl = get(CATEGORY_DIMENSION, KEY_intervention_dim_bl, new int[]{1}, "Dimensions from which teleportation by means of Divine intervention etc. should not be possible (default: the End)").getIntList();
+		rift_dim_bl = get(CATEGORY_DIMENSION, KEY_rift_dim_bl, new int[]{}, "Dimensions in which Rift storage is unaccessable").getIntList();
+	}
 
+	public int[] getInterventionDimBl() {
+		return intervention_dim_bl;
+	}
+
+	public int[] getRiftDimBl() {
+		return rift_dim_bl;
 	}
 }

--- a/src/main/java/am2/spell/components/DivineIntervention.java
+++ b/src/main/java/am2/spell/components/DivineIntervention.java
@@ -1,5 +1,6 @@
 package am2.spell.components;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Random;
 
@@ -41,7 +42,7 @@ public class DivineIntervention implements ISpellComponent{
 		catch(Exception e) {
 			FMLLog.info("[To_Craft] am2: " + e);
 		}
-		
+
 		if (world.isRemote || !(target instanceof EntityLivingBase)) return true;
 
 		if (((EntityLivingBase)target).isPotionActive(BuffList.astralDistortion.id)){
@@ -50,7 +51,7 @@ public class DivineIntervention implements ISpellComponent{
 			return true;
 		}
 
-		if (target.dimension == 1){
+		if (Arrays.stream(AMCore.skillConfig.getInterventionDimBl()).anyMatch(x -> x == target.dimension)){
 			if (target instanceof EntityPlayer)
 				((EntityPlayer)target).addChatMessage(new ChatComponentText("Nothing happens..."));
 			return true;

--- a/src/main/java/am2/spell/components/EnderIntervention.java
+++ b/src/main/java/am2/spell/components/EnderIntervention.java
@@ -2,6 +2,7 @@ package am2.spell.components;
 
 import java.util.EnumSet;
 import java.util.Random;
+import java.util.Arrays;
 
 import am2.AMCore;
 import am2.api.ArsMagicaApi;
@@ -39,7 +40,7 @@ public class EnderIntervention implements ISpellComponent{
 		catch(Exception e) {
 			FMLLog.info("[To_Craft] am2: " + e);
 		}
-		
+
 		if (world.isRemote || !(target instanceof EntityLivingBase)) return true;
 
 		if (((EntityLivingBase)target).isPotionActive(BuffList.astralDistortion.id)){
@@ -48,7 +49,7 @@ public class EnderIntervention implements ISpellComponent{
 			return true;
 		}
 
-		if (target.dimension == 1){
+		if (Arrays.stream(AMCore.skillConfig.getInterventionDimBl()).anyMatch(x -> x == target.dimension)){
 			if (target instanceof EntityPlayer)
 				((EntityPlayer)target).addChatMessage(new ChatComponentText("Nothing happens..."));
 			return true;

--- a/src/main/java/am2/spell/components/MysticalIntervention.java
+++ b/src/main/java/am2/spell/components/MysticalIntervention.java
@@ -2,6 +2,7 @@ package am2.spell.components;
 
 import java.util.EnumSet;
 import java.util.Random;
+import java.util.Arrays;
 
 import am2.AMCore;
 import am2.api.ArsMagicaApi;
@@ -54,7 +55,7 @@ public class MysticalIntervention implements ISpellComponent{
 			return true;
 		}
 
-		if (target.dimension == 1){
+		if (Arrays.stream(AMCore.skillConfig.getInterventionDimBl()).anyMatch(x -> x == target.dimension)){
 			if (target instanceof EntityPlayer)
 				((EntityPlayer)target).addChatMessage(new ChatComponentText("Nothing happens..."));
 			return true;

--- a/src/main/java/am2/spell/components/Rift.java
+++ b/src/main/java/am2/spell/components/Rift.java
@@ -1,5 +1,6 @@
 package am2.spell.components;
 
+import am2.AMCore;
 import am2.RitualShapeHelper;
 import am2.api.ArsMagicaApi;
 import am2.api.blocks.MultiblockStructureDefinition;
@@ -14,13 +15,16 @@ import am2.spell.SpellUtils;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
 
 import java.util.EnumSet;
 import java.util.Random;
+import java.util.Arrays;
 
 public class Rift implements ISpellComponent, IRitualInteraction{
 
@@ -47,6 +51,11 @@ public class Rift implements ISpellComponent, IRitualInteraction{
 		}
 
 		if (world.isRemote){
+			return true;
+		}
+		if (Arrays.stream(AMCore.skillConfig.getRiftDimBl()).anyMatch(x -> x == caster.dimension)){
+			if (caster instanceof EntityPlayer)
+				((EntityPlayer)caster).addChatMessage(new ChatComponentText("Nothing happens..."));
 			return true;
 		}
 		EntityRiftStorage storage = new EntityRiftStorage(world);

--- a/src/main/java/am2/spell/components/Sounds.java
+++ b/src/main/java/am2/spell/components/Sounds.java
@@ -23,10 +23,10 @@ public class Sounds implements ISpellComponent {
 	public boolean applyEffectEntity(ItemStack stack, World world, EntityLivingBase caster, Entity target) {
 		return applyEffect(stack, world, target.posX, target.posY, target.posZ);
 	}
-	
+
 	public boolean applyEffect(ItemStack stack, World world, double x, double y, double z) {
 		String sound = SpellUtils.instance.getSpellMetadata(stack, "Sound");
-		if (sound.isBlank()) sound = "botania:doit";
+		if (sound.trim().isEmpty()) sound = "botania:doit";
 		world.playSoundEffect(x, y, z, sound, 0.9F, world.rand.nextFloat() - world.rand.nextFloat() * 0.2F + 1.0F);
 		return true;
 	}
@@ -75,7 +75,7 @@ public class Sounds implements ISpellComponent {
 	public float getAffinityShift(Affinity affinity){
 		return 0.0f;
 	}
-	
+
 	public void setSound(ItemStack stack, ItemStack noteblockStack){
 		SpellUtils.instance.setSpellMetadata(stack, "Sound", noteblockStack.getDisplayName());
 	}


### PR DESCRIPTION
Dimension blacklists for Intervention and Rift components. The idea here is to be able to restrict these spells, e.g. in the Witchery Spirit World, where both either create problems (intervention) or go against the itended design (Rift).